### PR TITLE
Search Fix

### DIFF
--- a/GIF Control/GIFFetchController.cs
+++ b/GIF Control/GIFFetchController.cs
@@ -93,6 +93,15 @@ namespace GMDCGiphyPlugin.GIF_Control
             ConcurrentQueue<GIFData> gifDataOut = new ConcurrentQueue<GIFData>();
             var data = new GIFData();
 
+            if (gifType == GIFType.Trending)
+            {
+                trendingCancel = false;
+            }
+            else
+            {
+                searchCancel = false;
+            }
+
             while (count > 0)
             {
                 if (gifType == GIFType.Trending)


### PR DESCRIPTION
Fixes issue where if a Giphy server error occurs, further GIF fetching from the error path will no longer function